### PR TITLE
Fix file read when uploading to s3

### DIFF
--- a/aws/s3.go
+++ b/aws/s3.go
@@ -63,8 +63,12 @@ func (s S3) GetURLTemplate(option *media_library.Option) (path string) {
 }
 
 func (s S3) Store(url string, option *media_library.Option, reader io.Reader) error {
-	var buffer = []byte{}
-	reader.Read(buffer)
+	buffer, err := ioutil.ReadAll(reader)
+
+	if err != nil {
+		return err
+	}
+
 	fileBytes := bytes.NewReader(buffer)
 
 	path := strings.Replace(url, "//"+getEndpoint(option), "", -1)
@@ -82,7 +86,7 @@ func (s S3) Store(url string, option *media_library.Option, reader io.Reader) er
 		},
 	}
 
-	_, err := S3Client.PutObject(params)
+	_, err = S3Client.PutObject(params)
 	return err
 }
 


### PR DESCRIPTION
I'm was using the QOR Admin with the filesystem mode for testing purposes, but when I changed to s3 backend it not worked, on AWS S3 my images had 0 bytes, so I found out that the io.Reader was not being fully read. 
